### PR TITLE
Zero default LW

### DIFF
--- a/matplotlib-chord.py
+++ b/matplotlib-chord.py
@@ -6,7 +6,7 @@ import matplotlib.patches as patches
 
 import numpy as np
 
-LW = 0.3
+LW = 0
 
 def polar2xy(r, theta):
     return np.array([r*np.cos(theta), r*np.sin(theta)])


### PR DESCRIPTION
Having a default LW greater than 0 resulted in an unnecessary connection between nodes, even with 0 values in the matrix.
Like, for example, in this LDA topic modelling results:

```
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 294861, 102379, 0, 0, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 179786, 0, 0, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123373, 0, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 114517]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 88530]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67675, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 63946, 0, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 63348, 0, 0, 0, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62784, 0]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60785, 0, 0, 0, 0]
[294861, 0, 0, 0, 0, 0, 0, 63348, 0, 60785, 0, 0, 0, 0, 0]
[102379, 179786, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
[0, 0, 123373, 0, 0, 0, 63946, 0, 0, 0, 0, 0, 0, 0, 0]
[0, 0, 0, 0, 0, 67675, 0, 0, 62784, 0, 0, 0, 0, 0, 0]
[0, 0, 0, 114517, 88530, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```

Topics (last 5 cols & rows) wouldn't have connection to each other but had been referenced with a minimum width connection.
Leaving LW at 0 per default, resulted in a much cleaner correct diagram.

![LW_0 3](https://user-images.githubusercontent.com/824927/143421014-a98f6a2c-ca20-49f5-ba13-b2029614529a.png)

![LW_zero](https://user-images.githubusercontent.com/824927/143421008-728e5411-9124-46af-b63b-fcbadeef9d47.png)



 